### PR TITLE
Demonstrate loading of local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ information from diff data (a file, or stdin). For example:
     Total: 6 addition(s), 0 deletion(s)
 
 
+Reading local patch files
+-------------------------
+
+    >>> from unidiff import PatchSet
+    >>> with open('~/example.diff') as diff:
+    ...     patch = PatchSet(diff)
+    >>> patch
+    <PatchSet: [<PatchedFile: .gitignore>, <PatchedFile: unidiff/patch.py>, <PatchedFile: unidiff/utils.py>]>
+
+
 References
 ----------
 

--- a/unidiff/errors.py
+++ b/unidiff/errors.py
@@ -29,3 +29,6 @@ from __future__ import unicode_literals
 
 class UnidiffParseError(Exception):
     """Exception when parsing the unified diff data."""
+
+class UnidiffIOError(TypeError):
+    """Exception when parsing from a non-IO object."""

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -39,7 +39,7 @@ from unidiff.constants import (
     RE_SOURCE_FILENAME,
     RE_TARGET_FILENAME,
 )
-from unidiff.errors import UnidiffParseError
+from unidiff.errors import UnidiffParseError, UnidiffIOError
 
 
 PY2 = sys.version_info[0] == 2
@@ -274,6 +274,9 @@ class PatchSet(list):
 
     def _parse(self, diff):
         current_file = None
+
+        if not hasattr(diff, 'next'):
+            raise UnidiffIOError('Expected a file-like diff object.')
 
         for line in diff:
             # check for source file header


### PR DESCRIPTION
Maybe I hadn't had enought caffeine yet, but I had great difficulty loading a local patch file using unidiff. Part of this was due to no examples being given, but it was mostly due to the extremely cryptic error message/lack of error message given when the wrong type object is provided to `PatchSet`. I've given two example of the current state of affairs and a demo of what this fix does, below. These demos use a local file (`example.diff`) which is a downloaded version of the patch used in the existing `README` example.

# Example A (before fix):

```python
from unidiff import PatchSet

with open('example.diff', 'r+') as patch:
    patch = PatchSet(''.join(patch.readlines()))

print(repr(patch))
```

This yields:

```python
<PatchSet: []>
```

# Example B (before fix):

```python
from unidiff import PatchSet

with open('example.diff', 'r+') as patch:
    patch = PatchSet(patch.readlines())

print(repr(patch))
```

This yields:

```python
Traceback (most recent call last):
  File "/home/user//demo.py", line 15, in <module>
    patch = PatchSet(patch.readlines())
  File "/home/user/python-unidiff/unidiff/patch.py", line 267, in __init__
    self._parse(f)
  File "/home/user/python-unidiff/unidiff/patch.py", line 306, in _parse
    current_file._parse_hunk(line, diff)
  File "/home/user/python-unidiff/unidiff/patch.py", line 189, in _parse_hunk
    raise UnidiffParseError('Hunk diff line expected: %s' % line)
unidiff.errors.UnidiffParseError: Hunk diff line expected: diff --git a/.gitignore b/.gitignore
```

# After fix:

After this patch, the user will see something like so which, IMO, is a little more useful:

```python
Traceback (most recent call last):
  File "/home/user/demo.py", line 15, in <module>
    patch = PatchSet(''.join(patch.readlines()))
  File "/home/user/python-unidiff/unidiff/patch.py", line 267, in __init__
    self._parse(f)
  File "/home/user/python-unidiff/unidiff/patch.py", line 279, in _parse
    raise UnidiffIOError('Expected a file-like diff object.')
unidiff.errors.UnidiffIOError: Expected a file-like diff object.
```