### PR TITLE
Improve support for git patches

### DIFF
--- a/tests/samples/git.diff
+++ b/tests/samples/git.diff
@@ -20,7 +20,7 @@ index c7921f5..8946660 100644
 +This is now updated.
 +
 +This is a new line.
- 
+
  This will stay.
 \ No newline at end of file
 diff --git a/removed_file b/removed_file

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -38,15 +38,16 @@ RE_TARGET_FILENAME = re.compile(
 RE_HUNK_HEADER = re.compile(
     r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?\ @@[ ]?(.*)")
 
-#   kept line (context)
-# + added line
-# - deleted line
-# \ No newline case (ignore)
-RE_HUNK_BODY_LINE = re.compile(r'^(?P<line_type>[- \+\\])(?P<value>.*)')
-
+#    kept line (context)
+# \n empty line (treat like context)
+# +  added line
+# -  deleted line
+# \  No newline case (ignore)
+RE_HUNK_BODY_LINE = re.compile(r'^(?P<line_type>[- \n\+\\])(?P<value>.*)')
 
 DEFAULT_ENCODING = 'UTF-8'
 
 LINE_TYPE_ADDED = '+'
 LINE_TYPE_REMOVED = '-'
 LINE_TYPE_CONTEXT = ' '
+LINE_TYPE_EMPTY = '\n'

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -33,6 +33,7 @@ from unidiff.constants import (
     DEFAULT_ENCODING,
     LINE_TYPE_ADDED,
     LINE_TYPE_CONTEXT,
+    LINE_TYPE_EMPTY,
     LINE_TYPE_REMOVED,
     RE_HUNK_BODY_LINE,
     RE_HUNK_HEADER,
@@ -200,6 +201,13 @@ class PatchedFile(list):
                 original_line.source_line_no = source_line_no
                 source_line_no += 1
             elif line_type == LINE_TYPE_CONTEXT:
+                original_line.target_line_no = target_line_no
+                target_line_no += 1
+                original_line.source_line_no = source_line_no
+                source_line_no += 1
+            elif line_type == LINE_TYPE_EMPTY:
+                original_line.line_type = LINE_TYPE_CONTEXT
+                original_line.value = LINE_TYPE_EMPTY
                 original_line.target_line_no = target_line_no
                 target_line_no += 1
                 original_line.source_line_no = source_line_no


### PR DESCRIPTION
When git-2.4 formats a patch containing an unaltered empty line it
puts an empty line ('\n') in the output. unidiff expects such lines
to have a leading space (' \n') and throws an exception when presented
with such patches.

This patch fixes parser to cope with this input and updates the git
test file so that it contains an empty line.