### PR TITLE
include test sample data in tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include bin/*
+include tests/samples/*
 include HISTORY
 include LICENSE
 include README.md


### PR DESCRIPTION
In packaging this project for Fedora I noticed that the `tests/samples` directory is missing from tarballs published on PyPI. That means I can't run the tests as part of the build process.

This addition to `MANIFEST.in` should do the trick.