### PR TITLE
A few changes to handling newlines

### DIFF
--- a/tests/samples/sample3.diff
+++ b/tests/samples/sample3.diff
@@ -19,8 +19,9 @@
 +
 +This is a new line.
  
- This will stay.
+-This will stay.
 \ No newline at end of file
++This will stay.
 
 === removed file 'removed_file'
 --- removed_file	2013-10-13 23:53:13 +0000

--- a/tests/samples/sample4.diff
+++ b/tests/samples/sample4.diff
@@ -1,0 +1,34 @@
+=== added file 'added_file'
+--- added_file	1970-01-01 00:00:00 +0000
++++ added_file	2013-10-13 23:44:04 +0000
+@@ -0,0 +1,4 @@
++This was missing!
++holá mundo!
++
++Only for testing purposes.
+\ No newline at end of file
+
+=== modified file 'modified_file'
+--- modified_file	2013-10-13 23:53:13 +0000
++++ modified_file	2013-10-13 23:53:26 +0000
+@@ -1,5 +1,7 @@
+ This is the original content.
+ 
+-This should be updated.
++This is now updated.
++
++This is a new line.
+ 
+ This will stay.
+\ No newline at end of file
+
+=== removed file 'removed_file'
+--- removed_file	2013-10-13 23:53:13 +0000
++++ removed_file	1970-01-01 00:00:00 +0000
+@@ -1,3 +0,0 @@
+-This content shouldn't be here.
+-
+-This file will be removed.
+\ No newline at end of file
+
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -68,6 +68,20 @@ class TestUnidiffParser(unittest.TestCase):
         added_unicode_line = res.added_files[0][0][1]
         self.assertEqual(added_unicode_line.value, 'holá mundo!\n')
 
+    def test_no_newline_at_end_of_file(self):
+        utf8_file = os.path.join(self.samples_dir, 'samples/sample3.diff')
+        with open(utf8_file, 'rb') as diff_file:
+            res = PatchSet(diff_file, encoding='utf-8')
+
+        # 3 files updated by diff
+        self.assertEqual(len(res), 3)
+        added_unicode_line = res.added_files[0][0][4]
+        self.assertEqual(added_unicode_line.line_type, '\\')
+        self.assertEqual(added_unicode_line.value, ' No newline at end of file\n')
+        added_unicode_line = res.modified_files[0][0][8]
+        self.assertEqual(added_unicode_line.line_type, '\\')
+        self.assertEqual(added_unicode_line.value, ' No newline at end of file\n')
+
     def test_preserve_dos_line_endings(self):
         utf8_file = os.path.join(self.samples_dir, 'samples/sample4.diff')
         with open(utf8_file, 'rb') as diff_file:

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -43,7 +43,7 @@ RE_HUNK_HEADER = re.compile(
 # +  added line
 # -  deleted line
 # \  No newline case (ignore)
-RE_HUNK_BODY_LINE = re.compile(r'^(?P<line_type>[- \n\+\\])(?P<value>.*)')
+RE_HUNK_BODY_LINE = re.compile(r'^(?P<line_type>[- \n\+\\])(?P<value>.*)', re.DOTALL)
 
 DEFAULT_ENCODING = 'UTF-8'
 

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -42,8 +42,10 @@ RE_HUNK_HEADER = re.compile(
 # \n empty line (treat like context)
 # +  added line
 # -  deleted line
-# \  No newline case (ignore)
+# \  No newline case
 RE_HUNK_BODY_LINE = re.compile(r'^(?P<line_type>[- \n\+\\])(?P<value>.*)', re.DOTALL)
+
+RE_NO_NEWLINE_MARKER = re.compile(r'^\\ No newline at end of file')
 
 DEFAULT_ENCODING = 'UTF-8'
 
@@ -51,3 +53,5 @@ LINE_TYPE_ADDED = '+'
 LINE_TYPE_REMOVED = '-'
 LINE_TYPE_CONTEXT = ' '
 LINE_TYPE_EMPTY = '\n'
+LINE_TYPE_NO_NEWLINE = '\\'
+LINE_VALUE_NO_NEWLINE = ' No newline at end of file'

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -123,7 +123,7 @@ class Hunk(list):
         head = "@@ -%d,%d +%d,%d @@ %s\n" % (
             self.source_start, self.source_length,
             self.target_start, self.target_length, self.section_header)
-        content = '\n'.join(unicode(line) for line in self)
+        content = ''.join(unicode(line) for line in self)
         return head + content
 
     def append(self, line):
@@ -171,7 +171,7 @@ class PatchedFile(list):
     def __str__(self):
         source = "--- %s\n" % self.source_file
         target = "+++ %s\n" % self.target_file
-        hunks = '\n'.join(unicode(hunk) for hunk in self)
+        hunks = ''.join(unicode(hunk) for hunk in self)
         return source + target + hunks
 
     def _parse_hunk(self, header, diff, encoding):

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -35,10 +35,13 @@ from unidiff.constants import (
     LINE_TYPE_CONTEXT,
     LINE_TYPE_EMPTY,
     LINE_TYPE_REMOVED,
+    LINE_TYPE_NO_NEWLINE,
+    LINE_VALUE_NO_NEWLINE,
     RE_HUNK_BODY_LINE,
     RE_HUNK_HEADER,
     RE_SOURCE_FILENAME,
     RE_TARGET_FILENAME,
+    RE_NO_NEWLINE_MARKER,
 )
 from unidiff.errors import UnidiffParseError
 
@@ -208,6 +211,8 @@ class PatchedFile(list):
                 target_line_no += 1
                 original_line.source_line_no = source_line_no
                 source_line_no += 1
+            elif line_type == LINE_TYPE_NO_NEWLINE:
+                pass
             else:
                 original_line = None
 
@@ -221,6 +226,12 @@ class PatchedFile(list):
                 break
 
         self.append(hunk)
+
+    def _add_no_newline_marker_to_last_hunk(self):
+        if not self:
+            raise UnidiffParseError('Unexpected marker:' + LINE_VALUE_NO_NEWLINE)
+        last_hunk = self[-1]
+        last_hunk.append(Line(LINE_VALUE_NO_NEWLINE + '\n', line_type=LINE_TYPE_NO_NEWLINE))
 
     @property
     def path(self):
@@ -318,6 +329,13 @@ class PatchSet(list):
                 if current_file is None:
                     raise UnidiffParseError('Unexpected hunk found: %s' % line)
                 current_file._parse_hunk(line, diff, encoding)
+
+            # check for no newline marker
+            is_no_newline = RE_NO_NEWLINE_MARKER.match(line)
+            if is_no_newline:
+                if current_file is None:
+                    raise UnidiffParseError('Unexpected marker: %s' % line)
+                current_file._add_no_newline_marker_to_last_hunk()
 
     @classmethod
     def from_filename(cls, filename, encoding=DEFAULT_ENCODING, errors=None):


### PR DESCRIPTION
Two changes here:

1. Treat line endings as an integral part of hunk lines, therefore preserving them.
2. Preserve the No newline at end of file markers so that parsed patches can be reproduced exactly by printing.

Please review.