### PR TITLE
don't install tests as a top-level package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='mbordese@gmail.com',
     url='http://github.com/matiasb/python-unidiff',
     license='MIT',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     scripts=['bin/unidiff'],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Currently if you do `python setup.py install --root=somewhere` then you get a top-level package called `tests`:

```
[...]
creating somewhere/usr/lib/python2.7/site-packages/unidiff
copying build/lib/unidiff/__init__.py -> somewhere/usr/lib/python2.7/site-packages/unidiff
copying build/lib/unidiff/errors.py -> somewhere/usr/lib/python2.7/site-packages/unidiff
copying build/lib/unidiff/constants.py -> somewhere/usr/lib/python2.7/site-packages/unidiff
copying build/lib/unidiff/patch.py -> somewhere/usr/lib/python2.7/site-packages/unidiff
creating somewhere/usr/lib/python2.7/site-packages/tests
copying build/lib/tests/__init__.py -> somewhere/usr/lib/python2.7/site-packages/tests
copying build/lib/tests/test_hunks.py -> somewhere/usr/lib/python2.7/site-packages/tests
copying build/lib/tests/test_patchedfile.py -> somewhere/usr/lib/python2.7/site-packages/tests
copying build/lib/tests/test_line.py -> somewhere/usr/lib/python2.7/site-packages/tests
copying build/lib/tests/test_parser.py -> somewhere/usr/lib/python2.7/site-packages/tests
[...]
```

You probably don't want to install tests at all (or if you do, they should go into a proper package underneath `unidiff`).