### PR TITLE
Allow binary diffs to be acknowledged at a file level

### DIFF
--- a/tests/samples/sample8.diff
+++ b/tests/samples/sample8.diff
@@ -1,0 +1,11 @@
+diff --git a/foo.bin b/foo.bin
+new file mode 100644
+index 0000000..af000000
+Binary files /dev/null and b/foo.bin differ
+diff --git a/bar.bin b/bar.bin
+index ad000000..ac000000 100644
+Binary files a/bar.bin and b/bar.bin differ
+diff --git a/baz.bin b/baz.bin
+deleted file mode 100644
+index af000000..0000000
+Binary files a/baz.bin and /dev/null differ

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -222,6 +222,40 @@ class TestUnidiffParser(unittest.TestCase):
         with open(utf8_file, 'r') as diff_file:
             self.assertRaises(UnidiffParseError, PatchSet, diff_file)
 
+    def test_parse_diff_with_new_and_modified_binary_files(self):
+        """Parse git diff file with newly added and modified binaries files."""
+        utf8_file = os.path.join(self.samples_dir, 'samples/sample8.diff')
+        with open(utf8_file, 'r') as diff_file:
+            res = PatchSet(diff_file)
+
+        # three file in the patch
+        self.assertEqual(len(res), 3)
+
+        # first file is added
+        self.assertFalse(res[0].is_modified_file)
+        self.assertFalse(res[0].is_removed_file)
+        self.assertTrue(res[0].is_added_file)
+
+        # second file is added
+        self.assertTrue(res[1].is_modified_file)
+        self.assertFalse(res[1].is_removed_file)
+        self.assertFalse(res[1].is_added_file)
+
+        # third file is removed
+        self.assertFalse(res[2].is_modified_file)
+        self.assertTrue(res[2].is_removed_file)
+        self.assertFalse(res[2].is_added_file)
+
+    def test_parse_round_trip_with_binary_files_in_diff(self):
+        """Parse git diff with binary files though round trip"""
+        utf8_file = os.path.join(self.samples_dir, 'samples/sample8.diff')
+        with open(utf8_file, 'r') as diff_file:
+            res1 = PatchSet(diff_file)
+
+        res2 = PatchSet(str(res1))
+        self.assertEqual(res1, res2)
+
+
     def test_diff_lines_linenos(self):
         with open(self.sample_file, 'rb') as diff_file:
             res = PatchSet(diff_file, encoding='utf-8')

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -50,6 +50,9 @@ RE_HUNK_EMPTY_BODY_LINE = re.compile(
 
 RE_NO_NEWLINE_MARKER = re.compile(r'^\\ No newline at end of file')
 
+RE_BINARY_DIFF = re.compile(
+    r'^Binary files (?P<source_filename>[^\t\n]+) and (?P<target_filename>[^\t\n]+) differ')
+
 DEFAULT_ENCODING = 'UTF-8'
 
 LINE_TYPE_ADDED = '+'


### PR DESCRIPTION
Fixes #52

There are no hunks to show the diff of, but otherwise the patchinfo
lines were being discarded.

This is useful when using unidiff to identify changed files, not just
what changed in said files.

I would suggest at some point round-trip testing be considered, as I
expect in the current form, like with Binary diff mentions, some
patchinfo lines may be discarded.