### PR TITLE
Add unit test python files to release package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include bin/*
+include tests/*.py
 include tests/samples/*
 include HISTORY
 include LICENSE


### PR DESCRIPTION
This makes it possible to run the tests from the source release. It would even be better to make the tests a subpackage of the unidiff main package. That would make it even easier to run the tests after installing then with pip: `python -m unittest unidiff.test`