### PR TITLE
Optimize hunk parsing

### DIFF
--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -244,9 +244,9 @@ class PatchedFile(list):
             if encoding is not None:
                 line = line.decode(encoding)
 
-            valid_line = RE_HUNK_EMPTY_BODY_LINE.match(line)
+            valid_line = RE_HUNK_BODY_LINE.match(line)
             if not valid_line:
-                valid_line = RE_HUNK_BODY_LINE.match(line)
+                valid_line = RE_HUNK_EMPTY_BODY_LINE.match(line)
 
             if not valid_line:
                 raise UnidiffParseError('Hunk diff line expected: %s' % line)


### PR DESCRIPTION
During parsing we're currently match against an empty line first and if that fails, try to match against a non-empty line. This is inefficient because most lines in diffs contain some content, thus we end up with two regex matches for most lines.

Swapping the regex match operations makes this more efficient for the general case, because only one match would be performed. In fact, the only case when RE_HUNK_EMPTY_BODYLINE makes a difference is when the line consists only of newline characters.

This optimization results in unidiff binary being faster by around 10% for large textual diffs.