### PR TITLE
Add an option to parse only hunk positions

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -316,6 +316,38 @@ class TestUnidiffParser(unittest.TestCase):
         self.assertEqual(source_line_nos, expected_source_line_nos)
         self.assertEqual(diff_line_nos, expected_diff_line_nos)
 
+    def test_diff_hunk_positions(self):
+        with open(self.sample_file, 'rb') as diff_file:
+            res = PatchSet(diff_file, encoding='utf-8')
+        self.do_test_diff_hunk_positions(res)
+
+    def test_diff_hunk_positions_only_hunk_positions(self):
+        with open(self.sample_file, 'rb') as diff_file:
+            res = PatchSet(diff_file, encoding='utf-8', only_hunk_positions=True)
+        self.do_test_diff_hunk_positions(res)
+
+    def do_test_diff_hunk_positions(self, res):
+        hunk_positions = []
+        for diff_file in res:
+            for hunk in diff_file:
+                hunk_positions.append((hunk.source_start, hunk.target_start,
+                                       hunk.source_length, hunk.target_length))
+
+        expected_hunk_positions = [
+            # File: 1, Hunk: 1
+            (1, 1, 3, 9),
+            # File: 1, Hunk: 2
+            (5, 11, 16, 10),
+            # File: 1, Hunk: 3
+            (22, 22, 3, 7),
+            # File: 2, Hunk: 1
+            (0, 1, 0, 9),
+            # File: 3, Hunk: 1
+            (1, 0, 9, 0)
+        ]
+
+        self.assertEqual(hunk_positions, expected_hunk_positions)
+
 
 class TestVCSSamples(unittest.TestCase):
     """Tests for real examples from VCS."""

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -229,7 +229,7 @@ class PatchedFile(list):
         hunks = ''.join(unicode(hunk) for hunk in self)
         return info + source + target + hunks
 
-    def _parse_hunk(self, header, diff, encoding):
+    def _parse_hunk(self, header, diff, encoding, only_hunk_positions):
         """Parse hunk details."""
         header_info = RE_HUNK_HEADER.match(header)
         hunk_info = header_info.groups()
@@ -244,33 +244,53 @@ class PatchedFile(list):
             if encoding is not None:
                 line = line.decode(encoding)
 
-            valid_line = RE_HUNK_EMPTY_BODY_LINE.match(line)
-            if not valid_line:
-                valid_line = RE_HUNK_BODY_LINE.match(line)
+            if only_hunk_positions:
+                if not line:
+                    line_type = LINE_TYPE_CONTEXT
+                else:
+                    line_type = line[0]
 
-            if not valid_line:
-                raise UnidiffParseError('Hunk diff line expected: %s' % line)
+                if line_type == LINE_TYPE_ADDED:
+                    target_line_no += 1
+                elif line_type == LINE_TYPE_REMOVED:
+                    source_line_no += 1
+                elif line_type == LINE_TYPE_CONTEXT:
+                    target_line_no += 1
+                    source_line_no += 1
+                elif line_type == LINE_TYPE_NO_NEWLINE:
+                    pass
+                else:
+                    raise UnidiffParseError('Hunk diff line expected: %s' % line)
 
-            line_type = valid_line.group('line_type')
-            if line_type == LINE_TYPE_EMPTY:
-                line_type = LINE_TYPE_CONTEXT
-            value = valid_line.group('value')
-            original_line = Line(value, line_type=line_type)
-            if line_type == LINE_TYPE_ADDED:
-                original_line.target_line_no = target_line_no
-                target_line_no += 1
-            elif line_type == LINE_TYPE_REMOVED:
-                original_line.source_line_no = source_line_no
-                source_line_no += 1
-            elif line_type == LINE_TYPE_CONTEXT:
-                original_line.target_line_no = target_line_no
-                target_line_no += 1
-                original_line.source_line_no = source_line_no
-                source_line_no += 1
-            elif line_type == LINE_TYPE_NO_NEWLINE:
-                pass
-            else:
                 original_line = None
+            else:
+                valid_line = RE_HUNK_BODY_LINE.match(line)
+                if not valid_line:
+                    valid_line = RE_HUNK_EMPTY_BODY_LINE.match(line)
+
+                if not valid_line:
+                    raise UnidiffParseError('Hunk diff line expected: %s' % line)
+
+                line_type = valid_line.group('line_type')
+                if line_type == LINE_TYPE_EMPTY:
+                    line_type = LINE_TYPE_CONTEXT
+                value = valid_line.group('value')
+                original_line = Line(value, line_type=line_type)
+                if line_type == LINE_TYPE_ADDED:
+                    original_line.target_line_no = target_line_no
+                    target_line_no += 1
+                elif line_type == LINE_TYPE_REMOVED:
+                    original_line.source_line_no = source_line_no
+                    source_line_no += 1
+                elif line_type == LINE_TYPE_CONTEXT:
+                    original_line.target_line_no = target_line_no
+                    target_line_no += 1
+                    original_line.source_line_no = source_line_no
+                    source_line_no += 1
+                elif line_type == LINE_TYPE_NO_NEWLINE:
+                    pass
+                else:
+                    original_line = None
 
             # stop parsing if we got past expected number of lines
             if (source_line_no > expected_source_end or
@@ -360,7 +380,7 @@ class PatchedFile(list):
 class PatchSet(list):
     """A list of PatchedFiles."""
 
-    def __init__(self, f, encoding=None):
+    def __init__(self, f, encoding=None, only_hunk_positions=False):
         super(PatchSet, self).__init__()
 
         # convert string inputs to StringIO objects
@@ -370,7 +390,9 @@ class PatchSet(list):
         # make sure we pass an iterator object to parse
         data = iter(f)
         # if encoding is None, assume we are reading unicode data
-        self._parse(data, encoding=encoding)
+        # if only_hunk_positions is True, we perform only minimal parsing of lines within hunks.
+        # This is around 2.5-6 times faster than full parsing depending on Python version.
+        self._parse(data, encoding=encoding, only_hunk_positions=only_hunk_positions)
 
     def __repr__(self):
         return make_str('<PatchSet: %s>') % super(PatchSet, self).__repr__()
@@ -378,7 +400,7 @@ class PatchSet(list):
     def __str__(self):
         return ''.join(unicode(patched_file) for patched_file in self)
 
-    def _parse(self, diff, encoding):
+    def _parse(self, diff, encoding, only_hunk_positions):
         current_file = None
         patch_info = None
 
@@ -449,7 +471,7 @@ class PatchSet(list):
             if is_hunk_header:
                 if current_file is None:
                     raise UnidiffParseError('Unexpected hunk found: %s' % line)
-                current_file._parse_hunk(line, diff, encoding)
+                current_file._parse_hunk(line, diff, encoding, only_hunk_positions)
                 continue
 
             # check for no newline marker


### PR DESCRIPTION
In my use case I'm using this great library to figure out how code has moved around. For this use case the only thing that matters is the hunk positions and sizes. Unfortunately full diff parsing uses large amount of memory and is slow and there's no way to disable it in this library.

This PR adds a new option `only_hunk_positions` that enables a fast code path that only parses the hunk headers, only does minimal parsing of the line contents and does not store them. Enabling this option results in ~20 times less memory use and 6 times faster diff parsing on Python 3.6 (2.5 times on Python 2.7).