### PR TITLE
Fix an error when the first change is a binary

### DIFF
--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -513,6 +513,11 @@ class PatchSet(list):
                 current_file._append_trailing_empty_line()
                 continue
 
+            # if nothing has matched above then this line is a patch info
+            if patch_info is None:
+                current_file = None
+                patch_info = PatchInfo()
+
             is_binary_diff = RE_BINARY_DIFF.match(line)
             if is_binary_diff:
                 source_file = is_binary_diff.group('source_filename')
@@ -525,10 +530,6 @@ class PatchSet(list):
                 current_file = None
                 continue
 
-            # if nothing has matched above then this line is a patch info
-            if patch_info is None:
-                current_file = None
-                patch_info = PatchInfo()
             patch_info.append(line)
 
     @classmethod


### PR DESCRIPTION
This fixes a bug where, in a diff where the first change is a binary file, unidiff errors with
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.1_5/lib/python3.9/site-packages/unidiff/patch.py", line 538, in from_filename
    instance = cls(f)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.1_5/lib/python3.9/site-packages/unidiff/patch.py", line 421, in __init__
    self._parse(data, encoding=encoding, metadata_only=metadata_only)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.1_5/lib/python3.9/site-packages/unidiff/patch.py", line 520, in _parse
    patch_info.append(line)
AttributeError: 'NoneType' object has no attribute 'append'
```

Reproduction steps:
```sh
# Requires `go` to generate example binaries, but you can replace them
# with any two different binaries from any source

$ echo "package main\nfunc main(){}" > binary_a.go
$ go build binary_a.go
$ echo "package main\nimport \"fmt\"\nfunc main(){fmt.Println(\"HI\")}" > binary_b.go
$ go build binary_b.go
$ diff --unified binary_a binary_b > changes.diff
$ cat changes.diff
Binary files binary_a and binary_b differ
$ pip3 show unidiff
Name: unidiff
Version: 0.6.0
Summary: Unified diff parsing/metadata extraction library.
Home-page: http://github.com/matiasb/python-unidiff
Author: Matias Bordese
Author-email: mbordese@gmail.com
License: MIT
Location: /home/linuxbrew/.linuxbrew/lib/python3.9/site-packages
Requires: 
Required-by: 
$ python3
>>> from unidiff import PatchSet
>>> PatchSet.from_filename('./changes.diff')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.1_5/lib/python3.9/site-packages/unidiff/patch.py", line 538, in from_filename
    instance = cls(f)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.1_5/lib/python3.9/site-packages/unidiff/patch.py", line 421, in __init__
    self._parse(data, encoding=encoding, metadata_only=metadata_only)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.1_5/lib/python3.9/site-packages/unidiff/patch.py", line 520, in _parse
    patch_info.append(line)
AttributeError: 'NoneType' object has no attribute 'append'
>>>
```