### PR TITLE
Fix bug when processing diff with multiple renames.

### DIFF
--- a/tests/samples/git_rename.diff
+++ b/tests/samples/git_rename.diff
@@ -11,3 +11,17 @@ index a071991..4dbab21 100644
  Some content
 -Some content
 +Some modified content
+
+diff --git a/oldfile b/newfile
+similarity index 85%
+rename from oldfile
+rename to newfile
+index a071991..4dbab21 100644
+--- a/oldfile
++++ b/newfile
+@@ -9,4 +9,4 @@ Some content
+ Some content
+ Some content
+ Some content
+-Some content
++Some modified content

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -411,13 +411,29 @@ class TestVCSSamples(unittest.TestCase):
         with codecs.open(file_path, 'r', encoding='utf-8') as diff_file:
             res = PatchSet(diff_file)
 
-        self.assertEqual(len(res), 1)
+        self.assertEqual(len(res), 4)
 
         patch = res[0]
         self.assertTrue(patch.is_rename)
+        self.assertEqual(patch.added, 0)
+        self.assertEqual(patch.removed, 0)
+
+        patch = res[1]
+        self.assertFalse(patch.is_rename)
         self.assertEqual(patch.added, 1)
         self.assertEqual(patch.removed, 1)
-        self.assertEqual(len(res.modified_files), 1)
+
+        patch = res[2]
+        self.assertTrue(patch.is_rename)
+        self.assertEqual(patch.added, 0)
+        self.assertEqual(patch.removed, 0)
+
+        patch = res[3]
+        self.assertFalse(patch.is_rename)
+        self.assertEqual(patch.added, 1)
+        self.assertEqual(patch.removed, 1)
+
+        self.assertEqual(len(res.modified_files), 4)
         self.assertEqual(len(res.added_files), 0)
         self.assertEqual(len(res.removed_files), 0)
 

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -462,6 +462,7 @@ class PatchSet(list):
                     patch_info, source_file, target_file, None, None,
                     is_rename=True)
                 self.append(current_file)
+                patch_info = None
                 continue
 
             # check for source file header


### PR DESCRIPTION
Hi,

I found a bug, where diff's with multiple renames cause the "patchInfo" to be appended for each rename.
So each sucessive rename has its rename, plus all previous renames.

The diff I had the problem with is confidential, so I haven't created a test-case.
When you see the error, it should be obvious.

In anycase let me know if you want me to re-create another diff with the same issue.

Best

James