### PR TITLE
Remove an unused variable

### DIFF
--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -430,8 +430,7 @@ class PatchSet(list):
         current_file = None
         patch_info = None
 
-        diff = enumerate(diff, 1)
-        for unused_diff_line_no, line in diff:
+        for line in diff:
             if encoding is not None:
                 line = line.decode(encoding)
 


### PR DESCRIPTION
I don't understand the purpose of `unused_diff_line_no` is here. It does not appear to be used anywhere