### PR TITLE
added the newline parameter to PatchSet::from_filename and a test cas…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: self-hosted
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: ./run_tests.sh
+        run: $GITHUB_WORKSPACE/run_tests.sh
+        shell: bash
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,17 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: self-hosted
-
+    strategy:
+      matrix:
+        python-version: [ '2.x', '3.x']
+        
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: ${{ matrix.python-version }}
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
       # Runs a single command using the runners shell
       - name: Run a one-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: echo Hello, world!
+        run: ./run_tests.sh
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,3 @@ jobs:
         run: $GITHUB_WORKSPACE/run_tests.sh
         shell: bash
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,39 +1,28 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: self-hosted
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x']
+        python-version: [ '2.7', '3.6', '3.7', '3.8', '3.9' ]
       fail-fast: false  
       
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
+          architecture: 'x64' 
+      - name: 'Run Tests'
         run: $GITHUB_WORKSPACE/run_tests.sh
         shell: bash
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       matrix:
         python-version: [ '2.x', '3.x']
-        
+      fail-fast: false  
+      
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
       # Runs a single command using the runners shell
       - name: Run a one-line script
         run: $GITHUB_WORKSPACE/run_tests.sh

--- a/tests/samples/git_cr.diff
+++ b/tests/samples/git_cr.diff
@@ -1,0 +1,9 @@
+diff --git a/src/test/org/apache/commons/math/util/ExpandableDoubleArrayTest.java b/src/test/org/apache/commons/math/util/ExpandableDoubleArrayTest.java
+new file mode 100644
+index 000000000..2b38fa232
+--- /dev/null
++++ b/a.txt
+@@ -0,0 +1,3 @@
++ "This line is broken into two lines by CR. " +		"but it should be treated as one line in the text diff file"
++ "This has no CR"
++ "This line also has CR. " +              "but it should also be treated as one line in the text diff file". 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -237,7 +237,8 @@ class TestUnidiffParser(unittest.TestCase):
         self.assertRaises(UnidiffParseError, PatchSet.from_filename, utf8_file)
 
         ps1 = PatchSet.from_filename(utf8_file, newline='\n')
-        with open(utf8_file, 'r', newline='\n') as diff_file:
+        import io
+        with io.open(utf8_file, 'r', newline='\n') as diff_file:
             ps2 = PatchSet(diff_file)
 
         self.assertEqual(ps1, ps2)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -231,6 +231,17 @@ class TestUnidiffParser(unittest.TestCase):
         with open(utf8_file, 'r') as diff_file:
             self.assertRaises(UnidiffParseError, PatchSet, diff_file)
 
+    def test_from_filename_with_cr_in_diff_text_files(self):
+        """Parse git diff text files that contain CR"""
+        utf8_file = os.path.join(self.samples_dir, 'samples/git_cr.diff')
+        self.assertRaises(UnidiffParseError, PatchSet.from_filename, utf8_file)
+
+        ps1 = PatchSet.from_filename(utf8_file, newline='\n')
+        with open(utf8_file, 'r', newline='\n') as diff_file:
+            ps2 = PatchSet(diff_file)
+
+        self.assertEqual(ps1, ps2)
+
     def test_parse_diff_with_new_and_modified_binary_files(self):
         """Parse git diff file with newly added and modified binaries files."""
         utf8_file = os.path.join(self.samples_dir, 'samples/sample8.diff')

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -52,8 +52,10 @@ from unidiff.errors import UnidiffParseError
 
 PY2 = sys.version_info[0] == 2
 if PY2:
+    import io
     from StringIO import StringIO
-    open_file = codecs.open
+    # open_file = codecs.open
+    open_file = io.open
     make_str = lambda x: x.encode(DEFAULT_ENCODING)
 
     def implements_to_string(cls):

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -557,10 +557,10 @@ class PatchSet(list):
             patch_info.append(line)
 
     @classmethod
-    def from_filename(cls, filename, encoding=DEFAULT_ENCODING, errors=None):
+    def from_filename(cls, filename, encoding=DEFAULT_ENCODING, errors=None, newline=None):
         # type: (str, str, Optional[str]) -> PatchSet
         """Return a PatchSet instance given a diff filename."""
-        with open_file(filename, 'r', encoding=encoding, errors=errors) as f:
+        with open_file(filename, 'r', encoding=encoding, errors=errors, newline=newline) as f:
             instance = cls(f)
         return instance
 


### PR DESCRIPTION
I wonder if it is a good idea to add an "newline" parameter to PatchSet::from_filename. I am motivated by the following observations. 

- Git internally treats newline as '\n'. However, it doesn't prevent someone checking in a file that has '\r' or '\r\n' to a Git repository. Although it may be argued that it is a Git configuration error on the user's part, there are Git repositories that contains '\r', for instance, line [223](https://github.com/apache/commons-math/blob/e5833affa168b6e168d31bd24a2acbdf75f2d7ce/src/test/org/apache/commons/math/util/ExpandableDoubleArrayTest.java#L223) and [238](https://github.com/apache/commons-math/blob/e5833affa168b6e168d31bd24a2acbdf75f2d7ce/src/test/org/apache/commons/math/util/ExpandableDoubleArrayTest.java#L223) in a version of the ExpandableDoubleArrayTest.java of the Apache Commons Math project. 
- Although [Git-Diff](https://git-scm.com/docs/git-diff) has options to control whether to ignore '\r' or spaces, it does not remove '\r' when generating the diff file. As the result, a diff file may contain '\r'. unidiff cannot parse those diff's. PatchSet::from_filename would throw a UnidiffParseError exception. 
- I realize that we can pass a file to PatchSet::__init__ or create a PatchSet object from a string where we treat '\n' as the newline (turns off python's universal newline handling). However, I struggled to discover that it was the CR that caused my problems since I wished to write a one liner from the ouset (like PathSet.from_filename(diff_file)). I though adding this newline parameter would 1) raise the user's attention about the newline handling and 2) avoid a misuse (at present, we can argue that it is a misuse to do PathSet.from_filename(diff_file) when diff_file is a text file that has CR as a non-line-ending character). 

This patch contains two lines of change to parse.py, and a simple test diff file, and a test case in test_parse.py. 

Thank you.