### PR TITLE
added newline parameter to PatchSet::from_filename and test case with test diff file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Unidiff
 
 Simple Python library to parse and interact with unified diff data.
 
-.. image:: https://travis-ci.org/matiasb/python-unidiff.svg?branch=master
-    :target: https://travis-ci.org/matiasb/python-unidiff
+.. image:: https://www.travis-ci.com/matiasb/python-unidiff.svg?branch=master
+    :target: https://travis-ci.com/matiasb/python-unidiff
 
 Installing unidiff
 ------------------

--- a/tests/samples/git_cr.diff
+++ b/tests/samples/git_cr.diff
@@ -1,0 +1,9 @@
+diff --git a/src/test/org/apache/commons/math/util/ExpandableDoubleArrayTest.java b/src/test/org/apache/commons/math/util/ExpandableDoubleArrayTest.java
+new file mode 100644
+index 000000000..2b38fa232
+--- /dev/null
++++ b/a.txt
+@@ -0,0 +1,3 @@
++ "This line is broken into two lines by CR. " +		"but it should be treated as one line in the text diff file"
++ "This has no CR"
++ "This line also has CR. " +              "but it should also be treated as one line in the text diff file". 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -231,6 +231,18 @@ class TestUnidiffParser(unittest.TestCase):
         with open(utf8_file, 'r') as diff_file:
             self.assertRaises(UnidiffParseError, PatchSet, diff_file)
 
+    def test_from_filename_with_cr_in_diff_text_files(self):
+        """Parse git diff text files that contain CR"""
+        utf8_file = os.path.join(self.samples_dir, 'samples/git_cr.diff')
+        self.assertRaises(UnidiffParseError, PatchSet.from_filename, utf8_file)
+
+        ps1 = PatchSet.from_filename(utf8_file, newline='\n')
+        import io
+        with io.open(utf8_file, 'r', newline='\n') as diff_file:
+            ps2 = PatchSet(diff_file)
+
+        self.assertEqual(ps1, ps2)
+
     def test_parse_diff_with_new_and_modified_binary_files(self):
         """Parse git diff file with newly added and modified binaries files."""
         utf8_file = os.path.join(self.samples_dir, 'samples/sample8.diff')

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -52,8 +52,9 @@ from unidiff.errors import UnidiffParseError
 
 PY2 = sys.version_info[0] == 2
 if PY2:
+    import io
     from StringIO import StringIO
-    open_file = codecs.open
+    open_file = io.open
     make_str = lambda x: x.encode(DEFAULT_ENCODING)
 
     def implements_to_string(cls):
@@ -557,10 +558,10 @@ class PatchSet(list):
             patch_info.append(line)
 
     @classmethod
-    def from_filename(cls, filename, encoding=DEFAULT_ENCODING, errors=None):
+    def from_filename(cls, filename, encoding=DEFAULT_ENCODING, errors=None, newline=None):
         # type: (str, str, Optional[str]) -> PatchSet
         """Return a PatchSet instance given a diff filename."""
-        with open_file(filename, 'r', encoding=encoding, errors=errors) as f:
+        with open_file(filename, 'r', encoding=encoding, errors=errors, newline=newline) as f:
             instance = cls(f)
         return instance
 


### PR DESCRIPTION
This is to add the `newline` parameter to `PatchSet::from_filename`. 

This was originally submitted as pull request #83 that contains two changes
1. add the `newline` parameter and 
2. add Github Actions configuration file. 

This proposal only contains the changes for change 1 in the above.  Change 2 will be submitted as a separate proposal following this one. 