### PR TITLE
Fix issue #19: emtpy new git file

### DIFF
--- a/tests/samples/sample8.diff
+++ b/tests/samples/sample8.diff
@@ -1,3 +1,6 @@
+diff --git a/boo.bin b/boo.bin
+new file mode 100644
+index 0000000..ae000000
 diff --git a/foo.bin b/foo.bin
 new file mode 100644
 index 0000000..af000000
@@ -9,3 +12,6 @@ diff --git a/baz.bin b/baz.bin
 deleted file mode 100644
 index af000000..0000000
 Binary files a/baz.bin and /dev/null differ
+diff --git a/fuz.bin b/fuz.bin
+new file mode 100644
+index 0000000..ae000000

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -250,25 +250,37 @@ class TestUnidiffParser(unittest.TestCase):
             res = PatchSet(diff_file)
 
         # three file in the patch
-        self.assertEqual(len(res), 3)
+        self.assertEqual(len(res), 5)
 
-        # first file is added
+        # first empty file is added
         self.assertFalse(res[0].is_modified_file)
         self.assertFalse(res[0].is_removed_file)
         self.assertTrue(res[0].is_added_file)
-        self.assertTrue(res[0].is_binary_file)
+        self.assertFalse(res[0].is_binary_file)
 
-        # second file is modified
-        self.assertTrue(res[1].is_modified_file)
+        # second file is added
+        self.assertFalse(res[1].is_modified_file)
         self.assertFalse(res[1].is_removed_file)
-        self.assertFalse(res[1].is_added_file)
+        self.assertTrue(res[1].is_added_file)
         self.assertTrue(res[1].is_binary_file)
 
-        # third file is removed
-        self.assertFalse(res[2].is_modified_file)
-        self.assertTrue(res[2].is_removed_file)
+        # third file is modified
+        self.assertTrue(res[2].is_modified_file)
+        self.assertFalse(res[2].is_removed_file)
         self.assertFalse(res[2].is_added_file)
         self.assertTrue(res[2].is_binary_file)
+
+        # fourth file is removed
+        self.assertFalse(res[3].is_modified_file)
+        self.assertTrue(res[3].is_removed_file)
+        self.assertFalse(res[3].is_added_file)
+        self.assertTrue(res[3].is_binary_file)
+
+        # fifth empty file is added
+        self.assertFalse(res[4].is_modified_file)
+        self.assertFalse(res[4].is_removed_file)
+        self.assertTrue(res[4].is_added_file)
+        self.assertFalse(res[4].is_binary_file)
 
     def test_parse_round_trip_with_binary_files_in_diff(self):
         """Parse git diff with binary files though round trip"""

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -39,6 +39,10 @@ RE_TARGET_FILENAME = re.compile(
 RE_DIFF_GIT_HEADER = re.compile(
     r'^diff --git (?P<source>a/[^\t\n]+) (?P<target>b/[^\t\n]+)')
 
+# check diff git new file marker `new file mode 100644`
+RE_DIFF_GIT_NEW_FILE = re.compile(
+    r'^new file mode \d+\n$')
+
 
 # @@ (source offset, length) (target offset, length) @@ (section header)
 RE_HUNK_HEADER = re.compile(


### PR DESCRIPTION
Hello. I've faced the issue today in ClickHouse/ClickHouse#32911 that the empty new files aren't fetched. It means, our CI may not work correctly for some other edge cases.

Here I've implemented the parsing for such diffs and tests for them:

```diff
diff --git a/boo.bin b/boo.bin
new file mode 100644
index 0000000..ae000000
```

The PR fixes #19 