### PR TITLE
Make git prefix optional in regex

### DIFF
--- a/tests/samples/git_no_prefix.diff
+++ b/tests/samples/git_no_prefix.diff
@@ -1,0 +1,30 @@
+diff --git file1 file1
+deleted file mode 100644
+index 42f90fd..0000000
+--- file1
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line11
+-line12
+-line13
+diff --git file2 file2
+index c337bf1..1cb02b9 100644
+--- file2
++++ file2
+@@ -4,0 +5,3 @@ line24
++line24n
++line24n2
++line24n3
+@@ -15,0 +19,3 @@ line215
++line215n
++line215n2
++line215n3
+diff --git file3 file3
+new file mode 100644
+index 0000000..632e269
+--- /dev/null
++++ file3
+@@ -0,0 +1,3 @@
++line31
++line32
++line33

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -291,6 +291,28 @@ class TestUnidiffParser(unittest.TestCase):
         res2 = PatchSet(str(res1))
         self.assertEqual(res1, res2)
 
+    def test_parse_diff_git_no_prefix(self):
+        utf8_file = os.path.join(self.samples_dir, 'samples/git_no_prefix.diff')
+        with open(utf8_file, 'r') as diff_file:
+            res = PatchSet(diff_file)
+
+        self.assertEqual(len(res), 3)
+
+        self.assertEqual(res[0].source_file, 'file1')
+        self.assertEqual(res[0].target_file, '/dev/null')
+        self.assertTrue(res[0].is_removed_file)
+        self.assertEqual(res[0].path, 'file1')
+
+        self.assertEqual(res[1].source_file, 'file2')
+        self.assertEqual(res[1].target_file, 'file2')
+        self.assertTrue(res[1].is_modified_file)
+        self.assertEqual(res[1].path, 'file2')
+
+        self.assertEqual(res[2].source_file, '/dev/null')
+        self.assertEqual(res[2].target_file, 'file3')
+        self.assertTrue(res[2].is_added_file)
+        self.assertEqual(res[2].path, 'file3')
+
     def test_diff_lines_linenos(self):
         with open(self.sample_file, 'rb') as diff_file:
             res = PatchSet(diff_file, encoding='utf-8')

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -37,7 +37,7 @@ RE_TARGET_FILENAME = re.compile(
 
 # check diff git line for git renamed files support
 RE_DIFF_GIT_HEADER = re.compile(
-    r'^diff --git (?P<source>a/[^\t\n]+) (?P<target>b/[^\t\n]+)')
+    r'^diff --git (?P<source>(a/)?[^\t\n]+) (?P<target>(b/)?[^\t\n]+)')
 
 # check diff git new file marker `deleted file mode 100644`
 RE_DIFF_GIT_DELETED_FILE = re.compile(r'^deleted file mode \d+\n$')


### PR DESCRIPTION
Make git prefix optional when parsing a git header.

Related to #81. Still requiring support to allow custom prefixes, but fixes issue when --no-prefix is set.