### PR TITLE
Raw strings for RE_BINARY_DIFF

### DIFF
--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -64,8 +64,8 @@ RE_NO_NEWLINE_MARKER = re.compile(r'^\\ No newline at end of file')
 
 RE_BINARY_DIFF = re.compile(
     r'^Binary files? '
-    '(?P<source_filename>[^\t]+?)(?:\t(?P<source_timestamp>[\s0-9:\+-]+))?'
-    '(?: and (?P<target_filename>[^\t]+?)(?:\t(?P<target_timestamp>[\s0-9:\+-]+))?)? (differ|has changed)')
+    r'(?P<source_filename>[^\t]+?)(?:\t(?P<source_timestamp>[\s0-9:\+-]+))?'
+    r'(?: and (?P<target_filename>[^\t]+?)(?:\t(?P<target_timestamp>[\s0-9:\+-]+))?)? (differ|has changed)')
 
 DEFAULT_ENCODING = 'UTF-8'
 


### PR DESCRIPTION
`\s` isn't a valid backslash escape for a normal Python escape, which ends up
"working" since the `\s` gets preserved verbatim.

However, the invalid backslash escape can break other tools that process Python
source code, notably `pytest`s assertion rewriting.