### PR TITLE
Remove newline from RE_DIFF_GIT_{DELETED,NEW}_FILE

### DIFF
--- a/tests/samples/git_delete.diff
+++ b/tests/samples/git_delete.diff
@@ -1,0 +1,16 @@
+diff --git a/somefile.c b/somefile.c
+deleted file mode 100644
+index abcdefbbb8..0000000000
+--- a/somefile.c
++++ /dev/null
+@@ -1,10 +0,0 @@
+-/**
+- *  @file somefile.c
+- */
+-#include <stdio.h>
+-
+-int main(int argc, cahr *argv[])
+-{
+-	printf("Hello World\n");
+-	return 0;
+-}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -325,6 +325,16 @@ class TestUnidiffParser(unittest.TestCase):
         self.assertTrue(res[0].is_added_file)
         self.assertEqual(res[0].path, 'has spaces/t.sql')
 
+    def test_deleted_file(self):
+        filename = os.path.join(self.samples_dir, 'samples/git_delete.diff')
+        with open(filename) as f:
+            res = PatchSet(f)
+
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].source_file, 'a/somefile.c')
+        self.assertEqual(res[0].target_file, '/dev/null')
+        self.assertTrue(res[0].is_removed_file)
+
     def test_diff_lines_linenos(self):
         with open(self.sample_file, 'rb') as diff_file:
             res = PatchSet(diff_file, encoding='utf-8')

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -42,10 +42,10 @@ RE_DIFF_GIT_HEADER_NO_PREFIX = re.compile(
     r'^diff --git (?P<source>[^\t\n]+) (?P<target>[^\t\n]+)')
 
 # check diff git new file marker `deleted file mode 100644`
-RE_DIFF_GIT_DELETED_FILE = re.compile(r'^deleted file mode \d+\n$')
+RE_DIFF_GIT_DELETED_FILE = re.compile(r'^deleted file mode \d+$')
 
 # check diff git new file marker `new file mode 100644`
-RE_DIFF_GIT_NEW_FILE = re.compile(r'^new file mode \d+\n$')
+RE_DIFF_GIT_NEW_FILE = re.compile(r'^new file mode \d+$')
 
 
 # @@ (source offset, length) (target offset, length) @@ (section header)


### PR DESCRIPTION
RE_DIFF_GIT_DELETED_FILE and RE_DIFF_GIT_NEW_FILE match on a complete
line pattern 'r^$' so including `\n` in the pattern leads to the pattern
not matching. Remove the `\n`.