### PR TITLE
Fix issue with spaces in filename when using custom prefix

### DIFF
--- a/tests/samples/git_filenames_with_spaces_prefix.diff
+++ b/tests/samples/git_filenames_with_spaces_prefix.diff
@@ -1,0 +1,7 @@
+diff --git src://foo bar/baz dst://foo bar/baz
+new file mode 100644
+index 00000000000..0a72e5064c8
+--- /dev/null
++++ dst://foo bar/baz
+@@ -0,0 +1,1 @@
++blah

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -325,6 +325,18 @@ class TestUnidiffParser(unittest.TestCase):
         self.assertTrue(res[0].is_added_file)
         self.assertEqual(res[0].path, 'has spaces/t.sql')
 
+    def test_parse_filename_prefix_with_spaces(self):
+        filename = os.path.join(self.samples_dir, 'samples/git_filenames_with_spaces_prefix.diff')
+        with open(filename) as f:
+            res = PatchSet(f)
+
+        self.assertEqual(len(res), 1)
+
+        self.assertEqual(res[0].source_file, '/dev/null')
+        self.assertEqual(res[0].target_file, 'dst://foo bar/baz')
+        self.assertTrue(res[0].is_added_file)
+        self.assertEqual(res[0].path, 'dst://foo bar/baz')
+
     def test_deleted_file(self):
         filename = os.path.join(self.samples_dir, 'samples/git_delete.diff')
         with open(filename) as f:

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -38,6 +38,8 @@ RE_TARGET_FILENAME = re.compile(
 # check diff git line for git renamed files support
 RE_DIFF_GIT_HEADER = re.compile(
     r'^diff --git (?P<source>a/[^\t\n]+) (?P<target>b/[^\t\n]+)')
+RE_DIFF_GIT_HEADER_URI_LIKE = re.compile(
+    r'^diff --git (?P<source>.*://[^\t\n]+) (?P<target>.*://[^\t\n]+)')
 RE_DIFF_GIT_HEADER_NO_PREFIX = re.compile(
     r'^diff --git (?P<source>[^\t\n]+) (?P<target>[^\t\n]+)')
 

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -40,6 +40,7 @@ from unidiff.constants import (
     LINE_VALUE_NO_NEWLINE,
     RE_DIFF_GIT_DELETED_FILE,
     RE_DIFF_GIT_HEADER,
+    RE_DIFF_GIT_HEADER_URI_LIKE,
     RE_DIFF_GIT_HEADER_NO_PREFIX,
     RE_DIFF_GIT_NEW_FILE,
     RE_HUNK_BODY_LINE,
@@ -479,7 +480,9 @@ class PatchSet(list):
                 line = line.decode(encoding)
 
             # check for a git file rename
-            is_diff_git_header = RE_DIFF_GIT_HEADER.match(line) or RE_DIFF_GIT_HEADER_NO_PREFIX.match(line)
+            is_diff_git_header = RE_DIFF_GIT_HEADER.match(line) or \
+                RE_DIFF_GIT_HEADER_URI_LIKE.match(line) or \
+                RE_DIFF_GIT_HEADER_NO_PREFIX.match(line)
             if is_diff_git_header:
                 patch_info = PatchInfo()
                 source_file = is_diff_git_header.group('source')


### PR DESCRIPTION
Stash (Bitbucket) uses `src://` and `dst://` instead of `a` and `b`

Add a new handler for handling custom prefixes which allows for spaces.