### PR TITLE
Support extended git PatchFile Prefix

### DIFF
--- a/tests/test_patchedfile.py
+++ b/tests/test_patchedfile.py
@@ -52,3 +52,15 @@ class TestPatchedFile(unittest.TestCase):
         hunk = Hunk(src_start=1, src_len=10, tgt_start=1, tgt_len=8)
         self.patched_file.append(hunk)
         self.assertTrue(self.patched_file.is_modified_file)
+
+    def test_default_file_prefix(self):
+        default_prefix = PatchedFile(source="a/foo/", target="b/foo/")
+        self.assertTrue(default_prefix.path == "foo/")
+
+    def test_git_mnemonic_file_prefix(self):
+        default_prefix = PatchedFile(source="i/foo/", target="c/foo/")
+        self.assertTrue(default_prefix.path == "foo/")
+
+    def test_no_file_prefix(self):
+        default_prefix = PatchedFile(source="/foo/", target="/foo/")
+        self.assertTrue(default_prefix.path == "/foo/")

--- a/unidiff/constants.py
+++ b/unidiff/constants.py
@@ -71,6 +71,8 @@ RE_BINARY_DIFF = re.compile(
     r'(?P<source_filename>[^\t]+?)(?:\t(?P<source_timestamp>[\s0-9:\+-]+))?'
     r'(?: and (?P<target_filename>[^\t]+?)(?:\t(?P<target_timestamp>[\s0-9:\+-]+))?)? (differ|has changed)')
 
+RE_PATCH_FILE_PREFIX = re.compile(r"^[abciow12]/.*$")
+
 DEFAULT_ENCODING = 'UTF-8'
 
 DEV_NULL = '/dev/null'

--- a/unidiff/patch.py
+++ b/unidiff/patch.py
@@ -50,6 +50,7 @@ from unidiff.constants import (
     RE_TARGET_FILENAME,
     RE_NO_NEWLINE_MARKER,
     RE_BINARY_DIFF,
+    RE_PATCH_FILE_PREFIX,
 )
 from unidiff.errors import UnidiffParseError
 
@@ -397,7 +398,7 @@ class PatchedFile(list):
         if quoted:
             filepath = filepath[1:-1]
 
-        if filepath.startswith('a/') or filepath.startswith('b/'):
+        if RE_PATCH_FILE_PREFIX.match(filepath):
             filepath = filepath[2:]
 
         if quoted:


### PR DESCRIPTION
Extend support of traditional source/target Patch File prefix' to include git's
 [mnemonicPrefix](https://git-scm.com/docs/diff-config#Documentation/diff-config.txt-diffmnemonicPrefix).

- uses regex for prefix match
- adds tests for old and new behavior